### PR TITLE
avoid overflows in GCounter

### DIFF
--- a/bundle.json
+++ b/bundle.json
@@ -2,7 +2,7 @@
   "deps": [
     { "type": "github", "repo": "jemc/pony-jason" },
     {
-      "tag": "master",
+      "tag": "0.4.0",
       "type": "github",
       "repo": "mfelsche/ponycheck"
     }

--- a/crdt/g_counter.pony
+++ b/crdt/g_counter.pony
@@ -6,6 +6,12 @@ class ref GCounter[A: (Integer[A] val & Unsigned) = U64]
   """
   A mutable grow-only counter. That is, the value can only be increased.
 
+  It is limited by the maximum value of the used unsigned integer datatype.
+  Any operation that would lead to an overflow (if the maximum is the
+  maximum vlaue for the used unsigned integer type) will result in the value
+  being set to the maximum. So once the maximum is reached, the GCounter will
+  never change.
+
   This data type tracks the state seen from each replica, thus the size of the
   state will grow proportionally with the number of total replicas. New replicas
   may be added as peers at any time, provided that they use unique ids.
@@ -66,8 +72,16 @@ class ref GCounter[A: (Integer[A] val & Unsigned) = U64]
     Return the current value of the counter (the sum of all replica values).
     """
     var sum = A(0)
-    for v in _data.values() do sum = sum + v end
+    for v in _data.values() do sum = _sum(sum, v) end
     sum
+
+  fun _sum(x: A, y: A): A =>
+    (let sum: A, let overflow: Bool) = x.addc(y)
+    if overflow then
+      A.max_value()
+    else
+      sum
+    end
 
   fun ref _data_update(id': ID, value': A) => _data(id') = value'
 
@@ -80,7 +94,7 @@ class ref GCounter[A: (Integer[A] val & Unsigned) = U64]
     Accepts and returns a convergent delta-state.
     """
     try
-      let v' = _data.upsert(_id, value', {(v: A, value': A): A => v + value' })?
+      let v' = _data.upsert(_id, value', this~_sum())?
       _checklist_write()
       delta'._data_update(_id, v')
     end

--- a/crdt/g_counter.pony
+++ b/crdt/g_counter.pony
@@ -8,7 +8,7 @@ class ref GCounter[A: (Integer[A] val & Unsigned) = U64]
 
   It is limited by the maximum value of the used unsigned integer datatype.
   Any operation that would lead to an overflow (if the maximum is the
-  maximum vlaue for the used unsigned integer type) will result in the value
+  maximum value for the used unsigned integer type) will result in the value
   being set to the maximum. So once the maximum is reached, the GCounter will
   never change.
 
@@ -72,16 +72,8 @@ class ref GCounter[A: (Integer[A] val & Unsigned) = U64]
     Return the current value of the counter (the sum of all replica values).
     """
     var sum = A(0)
-    for v in _data.values() do sum = _sum(sum, v) end
+    for v in _data.values() do sum = _Math.saturated_sum[A](sum, v) end
     sum
-
-  fun _sum(x: A, y: A): A =>
-    (let sum: A, let overflow: Bool) = x.addc(y)
-    if overflow then
-      A.max_value()
-    else
-      sum
-    end
 
   fun ref _data_update(id': ID, value': A) => _data(id') = value'
 
@@ -94,7 +86,7 @@ class ref GCounter[A: (Integer[A] val & Unsigned) = U64]
     Accepts and returns a convergent delta-state.
     """
     try
-      let v' = _data.upsert(_id, value', this~_sum())?
+      let v' = _data.upsert(_id, value', {(x, y) => _Math.saturated_sum[A](x, y) })?
       _checklist_write()
       delta'._data_update(_id, v')
     end

--- a/crdt/test/main.pony
+++ b/crdt/test/main.pony
@@ -30,6 +30,7 @@ actor Main is TestList
     test(TestGCounter)
     test(TestGCounterDelta)
     test(TestGCounterTokens)
+    test(TestGCounterMax)
 
     test(TestPNCounter)
     test(TestPNCounterDelta)

--- a/crdt/test/test_g_counter.pony
+++ b/crdt/test/test_g_counter.pony
@@ -150,3 +150,36 @@ class TestGCounterTokens is UnitTest
     else
       h.fail("failed to parse token stream")
     end
+
+class TestGCounterMax is UnitTest
+  new iso create() => None
+  fun name(): String => "crdt.GCounter (max)"
+  fun apply(h: TestHelper) =>
+    let data   = GCounter[U8]("a".hash64())
+    let data'  = GCounter[U8]("b".hash64())
+    let data'' = GCounter[U8]("c".hash64())
+
+    data.increment(250)
+    data'.increment(253)
+    data''.increment(254)
+
+    h.assert_true(data.converge(data'))
+    h.assert_true(data.converge(data''))
+    h.assert_true(data'.converge(data))
+    h.assert_false(data'.converge(data'')) // data' == data''
+    h.assert_true(data''.converge(data))
+    h.assert_false(data''.converge(data')) // data'' == data'
+
+    data.increment(7)
+    data''.increment(1)
+
+    h.assert_true(data''.converge(data))
+    h.assert_false(data''.converge(data')) // data'' > data'
+
+    h.assert_eq[U8](data.value(), U8.max_value())
+    h.assert_eq[U8](data'.value(), U8.max_value())
+    h.assert_eq[U8](data''.value(), U8.max_value())
+
+    data.increment(42)
+    h.assert_eq[U8](data.value(), U8.max_value())
+


### PR DESCRIPTION
by saturating it at the datatypes maximum value. Once a GCounter reached its maximum,
it will forever remain at this maximum.

Fixes #4 

My first iteration contained a configurable maximum. But the change would have been to invasive, as none of the CRDTs is in anyway parameterized currently. The interface `Convergent` contains a constructor `_create_in` that is not compatible with instantiating a CRDT with state. (There are cumbersome workarounds, but none of them seemed desirable). So i ditched this idea.